### PR TITLE
(fix) add ssl reqs to sequelize for heroku remote pg access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ src/client/lib
 .floo*
 *.sqlite
 public
+.vscode

--- a/src/server/db/db.js
+++ b/src/server/db/db.js
@@ -1,13 +1,15 @@
 var Sequelize = require('sequelize');
 
-var url = process.env.DATABASE_URL || 'localhost';
-var dbname = 'd414dlcug3njlv';
-var username = 'dvxtkxwgylbtrz';
-var password = 'OkJpl2NmJfYhnlOSTjAepdXN29';
+var url = process.env.DATABASE_URL || 
+  'postgres://temhxbwqyzuvgl:ShZB_n-4FIZVt9SSvZ0aHix-je@ec2-107-22-235-119.compute-1.amazonaws.com:5432/daghgmnrb6tjeh';
 
-var sequelize = new Sequelize(dbname, username, password, {
-  host: url,
-  dialect: 'postgres'
+var sequelize = new Sequelize(url, {
+  'ssl': true,
+  'dialectOptions': {
+    'ssl': {
+      'require': true
+    }
+  }
 });
 
 module.exports = sequelize;


### PR DESCRIPTION
this is sort of a horrible fix, #45 

basically heroku requires ssl for remote database access (OK), so we add that in sequelize, which breaks access to local pg servers that apparently don't support SSL. also the mocha tests break now, but technically this fixes the database connection issue.

this pull request is more for the review app things.
